### PR TITLE
[DEVX-885] Remove broken file methods

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ scalacOptions := Seq(
 ) else Nil)
 
 enablePlugins(SbtPlugin)
-
+// bobingus
 scriptedBufferLog := false
 
 // Don't depend on publishLocal when running "scripted". This allows us to run

--- a/src/main/scala/fm/sbt/S3URLHandler.scala
+++ b/src/main/scala/fm/sbt/S3URLHandler.scala
@@ -193,11 +193,11 @@ object S3URLHandler {
     val roleBasedProviders: Vector[AwsCredentialsProvider] = Vector(
       new BucketSpecificRoleBasedEnvironmentVariableCredentialsProvider(basicProviderChain, bucket),
       new BucketSpecificRoleBasedSystemPropertiesCredentialsProvider(basicProviderChain, bucket),
-      new RoleBasedPropertiesFileCredentialsProvider(basicProviderChain, s".s3credentials_${bucket}"),
-      new RoleBasedPropertiesFileCredentialsProvider(basicProviderChain, s".${bucket}_s3credentials"),
+      // new RoleBasedPropertiesFileCredentialsProvider(basicProviderChain, s".s3credentials_${bucket}"),
+      // new RoleBasedPropertiesFileCredentialsProvider(basicProviderChain, s".${bucket}_s3credentials"),
       new RoleBasedEnvironmentVariableCredentialsProvider(basicProviderChain),
       new RoleBasedSystemPropertiesCredentialsProvider(basicProviderChain),
-      new RoleBasedPropertiesFileCredentialsProvider(basicProviderChain, s".s3credentials")
+      // new RoleBasedPropertiesFileCredentialsProvider(basicProviderChain, s".s3credentials")
     )
 
     AwsCredentialsProviderChain.builder().credentialsProviders((roleBasedProviders ++ basicProviders): _*).build()

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.0.0"
+ThisBuild / version := "1.0.1"


### PR DESCRIPTION
[DEVX-885] Remove broken file methods

These file methods were broken in the PR version that upgraded them to 2.0. Removing them as they do not work with the 2.0 AWS SDK at all.

## Test Plan

- Publish artifact locally 
- use new plugin verison in main AIQ repo
- confirm publishSnapshot and superApp publishDrivers are working

## Deploy Notes
Update version in AIQ repo after deploy


[DEVX-885]: https://actioniq.atlassian.net/browse/DEVX-885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ